### PR TITLE
Add Claude Desktop configuration and test instructions to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,6 +37,39 @@ npm start
 npm start -- --allowed-commands git,ls,node
 ```
 
+## Claude Desktopでの設定
+
+このMCPサーバーをClaude Desktopで使用するには、Claude Desktopの設定ファイル（通常は`~/.config/Claude Desktop/claude_desktop_config.json`）に以下のエントリを追加してください：
+
+```json
+{
+  "mcpServers": {
+    "guardrail": {
+      "command": "node",
+      "args": [
+        "/絶対パス/to/dist/index.js",
+        "--allowed-commands",
+        "git,ls,node,echo" // ここに許可するコマンドを追加
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+## 接続テスト
+
+サーバーが正しく動作しているか確認するには、以下を実行してください：
+
+```bash
+npm test
+```
+
+これにより、以下のテストが実行されます：
+
+- 許可されたコマンドの実行
+- 許可されていないコマンドの実行（拒否されるはず）
+
 ## セキュリティの注意点
 
 - コマンドリストには本当に必要なコマンドのみを許可してください

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Guardrail Server
 
+*Read this in other languages: [日本語](README.ja.md)*
+
 MCP Guardrail Server is a secure MCP (Model Context Protocol) server that executes only pre-authorized commands. It can be used in high-security environments to provide AI assistants with limited command execution capabilities.
 
 ## Features
@@ -36,6 +38,39 @@ npm start
 # Start with custom command list
 npm start -- --allowed-commands git,ls,node
 ```
+
+## Configuration with Claude Desktop
+
+To use this MCP server with Claude Desktop, add the following entry to your Claude Desktop configuration file (typically `~/.config/Claude Desktop/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "guardrail": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/dist/index.js",
+        "--allowed-commands",
+        "git,ls,node,echo" // Add your allowed commands here
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+## Connectivity Test
+
+To verify that the server is working correctly, run:
+
+```bash
+npm test
+```
+
+This will run the following tests:
+
+- Executing an allowed command
+- Attempting to execute an unauthorized command (which should be rejected)
 
 ## Security Notes
 


### PR DESCRIPTION
This PR adds documentation about how to configure the MCP Guardrail Server with Claude Desktop and explains how to run the test script to verify proper server functionality. Both English and Japanese README files are updated.